### PR TITLE
Feature/access token env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # yarn-plugin-gcp-auth
+
 [![Github Downloads](https://img.shields.io/github/downloads/AndyClausen/yarn-plugin-gcp-auth/total)]()
 
 Yarn Berry plugin to use gcloud auth for authentication to Google Artifact Registry packages
@@ -13,10 +14,13 @@ Yarn Berry plugin to use gcloud auth for authentication to Google Artifact Regis
 ### Per project setup
 
 To install the latest release use
+
 ```sh
 yarn plugin import https://github.com/AndyClausen/yarn-plugin-gcp-auth/releases/latest/download/plugin-gcp-auth.js
 ```
+
 or to install a specific version use
+
 ```sh
 yarn plugin import https://github.com/AndyClausen/yarn-plugin-gcp-auth/releases/download/X.Y.Z/plugin-gcp-auth.js
 ```
@@ -24,12 +28,13 @@ yarn plugin import https://github.com/AndyClausen/yarn-plugin-gcp-auth/releases/
 Then you will need to setup your .yarnrc.yml file to connect with Google Artifact Registry
 
 Example:
+
 ```yaml
 npmScopes:
   <org>:
     npmAlwaysAuth: true
-    npmPublishRegistry: "https://<location>-npm.pkg.dev/<org>/<repository>/"
-    npmRegistryServer: "https://<location>-npm.pkg.dev/<org>/<repository>/"
+    npmPublishRegistry: 'https://<location>-npm.pkg.dev/<org>/<repository>/'
+    npmRegistryServer: 'https://<location>-npm.pkg.dev/<org>/<repository>/'
 
 # Optional, only used for running/building on GCP VMs
 unsafeHttpWhitelist:
@@ -40,10 +45,9 @@ unsafeHttpWhitelist:
 
 - `yarn gcp-auth refresh`: clears plugin cache and forces the plugin to fetch a new token.
 
-
 ## Notes
 
-The plugin will first try to fetch a token from VM metadata (if you're running on gcp), then for your gcloud ADC, and *then* your normal gcloud auth.
+The plugin will first try to fetch a token from VM metadata (if you're running on gcp), then for your gcloud ADC, and _then_ your normal gcloud auth.
 To avoid this, log out of your ADC with `gcloud auth application-default revoke` and run `yarn gcp-auth refresh` (see [Commands](#commands)).
 
 If you are using this plugin during a docker build in Google Cloud Build, you need to use `--network=cloudbuild` in your `.yaml` so the container has access to GCP's metadata server. Read more [here](https://cloud.google.com/build/docs/build-config-file-schema#network).
@@ -64,7 +68,6 @@ docker build --tag my-image --build-arg ACCESS_TOKEN=$(gcloud auth application-d
 ```Dockerfile
 # in your build stage
 ARG ACCESS_TOKEN
-ENV ACCESS_TOKEN=$ACCESS_TOKEN
 RUN yarn
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # yarn-plugin-gcp-auth
-
 [![Github Downloads](https://img.shields.io/github/downloads/AndyClausen/yarn-plugin-gcp-auth/total)]()
 
 Yarn Berry plugin to use gcloud auth for authentication to Google Artifact Registry packages
@@ -14,13 +13,10 @@ Yarn Berry plugin to use gcloud auth for authentication to Google Artifact Regis
 ### Per project setup
 
 To install the latest release use
-
 ```sh
 yarn plugin import https://github.com/AndyClausen/yarn-plugin-gcp-auth/releases/latest/download/plugin-gcp-auth.js
 ```
-
 or to install a specific version use
-
 ```sh
 yarn plugin import https://github.com/AndyClausen/yarn-plugin-gcp-auth/releases/download/X.Y.Z/plugin-gcp-auth.js
 ```
@@ -28,13 +24,12 @@ yarn plugin import https://github.com/AndyClausen/yarn-plugin-gcp-auth/releases/
 Then you will need to setup your .yarnrc.yml file to connect with Google Artifact Registry
 
 Example:
-
 ```yaml
 npmScopes:
   <org>:
     npmAlwaysAuth: true
-    npmPublishRegistry: 'https://<location>-npm.pkg.dev/<org>/<repository>/'
-    npmRegistryServer: 'https://<location>-npm.pkg.dev/<org>/<repository>/'
+    npmPublishRegistry: "https://<location>-npm.pkg.dev/<org>/<repository>/"
+    npmRegistryServer: "https://<location>-npm.pkg.dev/<org>/<repository>/"
 
 # Optional, only used for running/building on GCP VMs
 unsafeHttpWhitelist:
@@ -45,9 +40,10 @@ unsafeHttpWhitelist:
 
 - `yarn gcp-auth refresh`: clears plugin cache and forces the plugin to fetch a new token.
 
+
 ## Notes
 
-The plugin will first try to fetch a token from VM metadata (if you're running on gcp), then for your gcloud ADC, and _then_ your normal gcloud auth.
+The plugin will first try to fetch a token from VM metadata (if you're running on gcp), then for your gcloud ADC, and *then* your normal gcloud auth.
 To avoid this, log out of your ADC with `gcloud auth application-default revoke` and run `yarn gcp-auth refresh` (see [Commands](#commands)).
 
 If you are using this plugin during a docker build in Google Cloud Build, you need to use `--network=cloudbuild` in your `.yaml` so the container has access to GCP's metadata server. Read more [here](https://cloud.google.com/build/docs/build-config-file-schema#network).

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ You will also need to whitelist the metadata url as shown in the .yarnrc.yml exa
 
 Tokens are being cached since v1.1.0, and will be used until they expire (usually up to an hour) or until they're refreshed manually (see [Commands](#commands)).
 
+## Local docker build
+
+You probably won't have `gcloud` installed in your docker container, so as a workaround for testing local builds, you can pass your access token in to use as an environment variable.
+
+> This should not be used in production, as it may bake your access token into your docker image.
+
+```sh
+docker build --tag my-image --build-arg ACCESS_TOKEN=$(gcloud auth application-default print-access-token) .
+```
+
+```Dockerfile
+# in your build stage
+ARG ACCESS_TOKEN
+ENV ACCESS_TOKEN=$ACCESS_TOKEN
+RUN yarn
+```
 
 ### Credits
 

--- a/src/helpers/refresh-token.ts
+++ b/src/helpers/refresh-token.ts
@@ -24,10 +24,15 @@ export async function refreshToken(configuration: Configuration): Promise<string
     ({ access_token: token, expires_in: expiresIn } = res.body);
     token = token.trim();
   } catch {
-    try {
-      token = await gcloud(configuration, 'auth', 'application-default', 'print-access-token');
-    } catch {
-      token = await gcloud(configuration, 'auth', 'print-access-token');
+    if (process.env.ACCESS_TOKEN) {
+      token = process.env.ACCESS_TOKEN;
+    } else {
+
+      try {
+        token = await gcloud(configuration, 'auth', 'application-default', 'print-access-token');
+      } catch {
+        token = await gcloud(configuration, 'auth', 'print-access-token');
+      }
     }
 
     token = token


### PR DESCRIPTION
Thanks for the awesome plugin! We've been using it seamlessly at work for over a year now and it makes it a dream to auth both locally and in cloud build! 

Finally ran into our first issue this week, it is about having a local docker build strategy. Our devOps team needed to be able to only run docker containers locally in order to debug builds and issues, but I couldn't figure out a way for them to successfully authenticate inside of docker in the current transparent way. Being able to pass in your `ACCESS_TOKEN` as a build arg made that possible. 

Currently we are using this forked release and it seems to be doing the job. Let me know if there is anything else I can do to support this plugin!