### PR TITLE
Support for 'GCE_METADATA_HOST' environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ npmScopes:
     npmPublishRegistry: "https://<location>-npm.pkg.dev/<org>/<repository>/"
     npmRegistryServer: "https://<location>-npm.pkg.dev/<org>/<repository>/"
 
-# Optional, only used for running/building on GCP VMs
+# Optional, only used for running/building on GCP VMs, or if providing custom (proxy or emulator) host as metadata source.
 unsafeHttpWhitelist:
-  - metadata.google.internal
+  - ${GCE_METADATA_HOST:-metadata.google.internal}
+
 ```
 
 ## Commands
@@ -43,7 +44,7 @@ unsafeHttpWhitelist:
 
 ## Notes
 
-The plugin will first try to fetch a token from VM metadata (if you're running on gcp), then for your gcloud ADC, and *then* your normal gcloud auth.
+The plugin will first try to fetch a token from VM metadata (using default host `metadata.google.internal` if you're running on gcp, alternate metadata host can be provided via [GCE_METADATA_HOST](https://cloud.google.com/nodejs/docs/reference/gcp-metadata/latest#environment-variables) environment variable), then for your gcloud ADC, and *then* your normal gcloud auth.
 To avoid this, log out of your ADC with `gcloud auth application-default revoke` and run `yarn gcp-auth refresh` (see [Commands](#commands)).
 
 If you are using this plugin during a docker build in Google Cloud Build, you need to use `--network=cloudbuild` in your `.yaml` so the container has access to GCP's metadata server. Read more [here](https://cloud.google.com/build/docs/build-config-file-schema#network).

--- a/src/helpers/refresh-token.ts
+++ b/src/helpers/refresh-token.ts
@@ -8,9 +8,10 @@ export async function refreshToken(configuration: Configuration): Promise<string
 
   try {
     // First check if we're in a GCP VM
+    const metadataHost = process.env.GCE_METADATA_HOST || 'metadata.google.internal'
     // Use `httpUtils.request` instead of `httpUtils.get` to avoid caching.
     const res = await httpUtils.request(
-      'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+      `http://${metadataHost}/computeMetadata/v1/instance/service-accounts/default/token`,
       null,
       {
         configuration,


### PR DESCRIPTION
Thiis PR adds support for official [GCE_METADATA_HOST](https://cloud.google.com/nodejs/docs/reference/gcp-metadata/latest#environment-variables) variable.

Ability to use custom host for GCE metadata  allows to use proxies in production. Also greatly simplifies pre-live / build /  development environments, where multistage docker builds can obtain token from [emulator](https://github.com/salrashid123/gce_metadata_server) without need to provide ACCESS_TOKEN as docker secret on command-line.