### PR TITLE
make the plugin to be a no-op when running in dependabot env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ const plugin: Plugin<NpmHooks> = {
       if (!registry.includes('npm.pkg.dev/')) {
         return null;
       }
+
+      if (process.env.DEPENDABOT) {
+        console.warn('Dependabot detected, skipping GCP authentication');
+        return currentHeader;
+      }
+
       const cache = configuration.get('gcpAccessToken');
       let token: string = cache.get('token');
       if (!token || cache.get('expiresAt') < Date.now() + 1000) {


### PR DESCRIPTION
Closes #9.

I decided to keep the current behaviour by default (and fail if gcloud is missing, etc). However, having in mind that dependabot uses a different way of authentication for GCP artifact registry, I think it is easier to just make the plugin to act as a no-op in case yarn runs in the context of a dependabot update (env variable taken from https://github.com/dependabot/dependabot-core?rgh-link-date=2024-12-12T10%3A09%3A37Z#dependabot-on-ci)